### PR TITLE
Remove leading zeros from IPv6 test strings

### DIFF
--- a/cidrtypes/ipv6_prefix_value_test.go
+++ b/cidrtypes/ipv6_prefix_value_test.go
@@ -48,8 +48,8 @@ func TestIPv6PrefixStringSemanticEquals(t *testing.T) {
 			expectedMatch:   true,
 		},
 		"semantically equal - case insensitive": {
-			currentIpPrefix: cidrtypes.NewIPv6PrefixValue("2001:0DB8:0000:0000:0008:0800:0200C:417A/60"),
-			givenIpPrefix:   cidrtypes.NewIPv6PrefixValue("2001:0db8:0000:0000:0008:0800:0200c:417a/60"),
+			currentIpPrefix: cidrtypes.NewIPv6PrefixValue("2001:0DB8:0000:0000:0008:0800:200C:417A/60"),
+			givenIpPrefix:   cidrtypes.NewIPv6PrefixValue("2001:0db8:0000:0000:0008:0800:200c:417a/60"),
 			expectedMatch:   true,
 		},
 		"semantically equal - IPv4-Mapped byte-for-byte match": {
@@ -63,7 +63,7 @@ func TestIPv6PrefixStringSemanticEquals(t *testing.T) {
 			expectedMatch:   true,
 		},
 		"semantically equal - compressed all leading zeroes match": {
-			currentIpPrefix: cidrtypes.NewIPv6PrefixValue("2001:0DB8:0000:0000:0008:0800:0200C:417A/60"),
+			currentIpPrefix: cidrtypes.NewIPv6PrefixValue("2001:0DB8:0000:0000:0008:0800:200C:417A/60"),
 			givenIpPrefix:   cidrtypes.NewIPv6PrefixValue("2001:DB8::8:800:200C:417A/60"),
 			expectedMatch:   true,
 		},

--- a/iptypes/ipv6_address_value_test.go
+++ b/iptypes/ipv6_address_value_test.go
@@ -48,8 +48,8 @@ func TestIPv6AddressStringSemanticEquals(t *testing.T) {
 			expectedMatch: true,
 		},
 		"semantically equal - case insensitive": {
-			currentIpAddr: iptypes.NewIPv6AddressValue("2001:0DB8:0000:0000:0008:0800:0200C:417A"),
-			givenIpAddr:   iptypes.NewIPv6AddressValue("2001:0db8:0000:0000:0008:0800:0200c:417a"),
+			currentIpAddr: iptypes.NewIPv6AddressValue("2001:0DB8:0000:0000:0008:0800:200C:417A"),
+			givenIpAddr:   iptypes.NewIPv6AddressValue("2001:0db8:0000:0000:0008:0800:200c:417a"),
 			expectedMatch: true,
 		},
 		"semantically equal - IPv4-Mapped byte-for-byte match": {
@@ -63,7 +63,7 @@ func TestIPv6AddressStringSemanticEquals(t *testing.T) {
 			expectedMatch: true,
 		},
 		"semantically equal - compressed all leading zeroes match": {
-			currentIpAddr: iptypes.NewIPv6AddressValue("2001:0DB8:0000:0000:0008:0800:0200C:417A"),
+			currentIpAddr: iptypes.NewIPv6AddressValue("2001:0DB8:0000:0000:0008:0800:200C:417A"),
 			givenIpAddr:   iptypes.NewIPv6AddressValue("2001:DB8::8:800:200C:417A"),
 			expectedMatch: true,
 		},


### PR DESCRIPTION
There are a few IPv6 test strings with a 5-character chazwazza. For example:

2001:0DB8:0000:0000:0008:0800:**0200C**:417A/60

The leading zero doesn't affect the test outcome, but it looks like a mistake, rather than a deliberate effort to exercise parsing of a near-bogus IPv6 address.

Closes #71