### PR TITLE
Chore: golangci-lint fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,13 @@
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - gofmt
     - gosimple
@@ -19,7 +19,7 @@ linters:
     - paralleltest
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
+    - usetesting

--- a/cidrtypes/ipv4_prefix_type_test.go
+++ b/cidrtypes/ipv4_prefix_type_test.go
@@ -39,7 +39,7 @@ func TestIPv4PrefixTypeValueFromTerraform(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/cidrtypes/ipv4_prefix_value_test.go
+++ b/cidrtypes/ipv4_prefix_value_test.go
@@ -113,7 +113,7 @@ func TestIPv4PrefixValidateAttribute(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -218,7 +218,7 @@ func TestIPv4PrefixValidateParameter(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -271,7 +271,7 @@ func TestIPv4PrefixValueIPv4Prefix(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cidrtypes/ipv6_prefix_type_test.go
+++ b/cidrtypes/ipv6_prefix_type_test.go
@@ -39,7 +39,7 @@ func TestIPv6PrefixTypeValueFromTerraform(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/cidrtypes/ipv6_prefix_value_test.go
+++ b/cidrtypes/ipv6_prefix_value_test.go
@@ -103,7 +103,7 @@ func TestIPv6PrefixStringSemanticEquals(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -234,7 +234,7 @@ func TestIPv6PrefixValidateAttribute(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -357,7 +357,7 @@ func TestIPv6PrefixValidateParameter(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -410,7 +410,7 @@ func TestIPv6PrefixValueIPv6Prefix(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/iptypes/ipv4_address_type_test.go
+++ b/iptypes/ipv4_address_type_test.go
@@ -39,7 +39,7 @@ func TestIPv4AddressTypeValueFromTerraform(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/iptypes/ipv4_address_value_test.go
+++ b/iptypes/ipv4_address_value_test.go
@@ -101,7 +101,7 @@ func TestIPv4AddressValidateAttribute(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -194,7 +194,7 @@ func TestIPv4AddressValidateParameter(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -247,7 +247,7 @@ func TestIPv4AddressValueIPv4Address(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/iptypes/ipv6_address_type_test.go
+++ b/iptypes/ipv6_address_type_test.go
@@ -39,7 +39,7 @@ func TestIPv6AddressTypeValueFromTerraform(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/iptypes/ipv6_address_value_test.go
+++ b/iptypes/ipv6_address_value_test.go
@@ -103,7 +103,7 @@ func TestIPv6AddressStringSemanticEquals(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -210,7 +210,7 @@ func TestIPv6AddressValidateAttribute(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -311,7 +311,7 @@ func TestIPv6AddressValidateParameter(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -364,7 +364,7 @@ func TestIPv6AddressValueIPv6Address(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
- Replace `max-per-linter` with `max-issues-per-linters`
- Replace `exportloopref` linter with `copyloopvar`
- Replace `tenv` linter with `usetesting`