### PR TITLE
Fix tautological condition in tests

### DIFF
--- a/cidrtypes/ipv4_prefix_type_test.go
+++ b/cidrtypes/ipv4_prefix_type_test.go
@@ -54,7 +54,7 @@ func TestIPv4PrefixTypeValueFromTerraform(t *testing.T) {
 				}
 				return
 			}
-			if err == nil && testCase.expectedErr != "" {
+			if testCase.expectedErr != "" {
 				t.Fatalf("Expected error to be %q, didn't get an error", testCase.expectedErr)
 			}
 			if !got.Equal(testCase.expectation) {

--- a/cidrtypes/ipv6_prefix_type_test.go
+++ b/cidrtypes/ipv6_prefix_type_test.go
@@ -54,7 +54,7 @@ func TestIPv6PrefixTypeValueFromTerraform(t *testing.T) {
 				}
 				return
 			}
-			if err == nil && testCase.expectedErr != "" {
+			if testCase.expectedErr != "" {
 				t.Fatalf("Expected error to be %q, didn't get an error", testCase.expectedErr)
 			}
 			if !got.Equal(testCase.expectation) {

--- a/iptypes/ipv4_address_type_test.go
+++ b/iptypes/ipv4_address_type_test.go
@@ -54,7 +54,7 @@ func TestIPv4AddressTypeValueFromTerraform(t *testing.T) {
 				}
 				return
 			}
-			if err == nil && testCase.expectedErr != "" {
+			if testCase.expectedErr != "" {
 				t.Fatalf("Expected error to be %q, didn't get an error", testCase.expectedErr)
 			}
 			if !got.Equal(testCase.expectation) {

--- a/iptypes/ipv6_address_type_test.go
+++ b/iptypes/ipv6_address_type_test.go
@@ -54,7 +54,7 @@ func TestIPv6AddressTypeValueFromTerraform(t *testing.T) {
 				}
 				return
 			}
-			if err == nil && testCase.expectedErr != "" {
+			if testCase.expectedErr != "" {
 				t.Fatalf("Expected error to be %q, didn't get an error", testCase.expectedErr)
 			}
 			if !got.Equal(testCase.expectation) {


### PR DESCRIPTION
These `err == nil` are not necessary because the `err` has already been checked earlier.